### PR TITLE
feat: allow passing options to yaml parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,14 +6,19 @@ var yamlParse = require('js-yaml').load
 module.exports = matter
 
 function matter(file, options) {
-  var strip = (options || {}).strip
+  options = options || {}
+  var strip = options.strip
+  var yamlOptions = options.yaml || {}
   var doc = String(file)
   var match = /^---(?:\r?\n|\r)(?:([\s\S]*)(?:\r?\n|\r))?---(?:\r?\n|\r|$)/.exec(
     doc
   )
 
   if (match) {
-    file.data.matter = yamlParse(match[1], {filename: file.path})
+    file.data.matter = yamlParse(
+      match[1],
+      Object.assign(yamlOptions, {filename: file.path})
+    )
 
     if (strip) {
       doc = doc.slice(match[0].length)

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ var yamlParse = require('js-yaml').load
 module.exports = matter
 
 function matter(file, options) {
-  options = options || {}
-  var strip = options.strip
-  var yamlOptions = options.yaml || {}
+  var settings = options || {}
+  var strip = settings.strip
+  var yamlOptions = settings.yaml || {}
   var doc = String(file)
   var match = /^---(?:\r?\n|\r)(?:([\s\S]*)(?:\r?\n|\r))?---(?:\r?\n|\r|$)/.exec(
     doc
@@ -17,7 +17,7 @@ function matter(file, options) {
   if (match) {
     file.data.matter = yamlParse(
       match[1],
-      Object.assign(yamlOptions, {filename: file.path})
+      Object.assign({}, yamlOptions, {filename: file.path})
     )
 
     if (strip) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "js-yaml": "^4.0.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.0",
     "dtslint": "^4.0.0",
     "nyc": "^15.0.0",
     "prettier": "^2.0.0",
@@ -72,7 +73,8 @@
     "rules": {
       "guard-for-in": "off",
       "unicorn/prefer-includes": "off"
-    }
+    },
+    "ignores": ["types"]
   },
   "remarkConfig": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -74,7 +74,9 @@
       "guard-for-in": "off",
       "unicorn/prefer-includes": "off"
     },
-    "ignores": ["types"]
+    "ignores": [
+      "types/"
+    ]
   },
   "remarkConfig": {
     "plugins": [

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var test = require('tape')
 var buffer = require('is-buffer')
 var vfile = require('to-vfile')
 var matter = require('.')
+var CORE_SCHEMA = require('js-yaml').CORE_SCHEMA
 
 var yaml = '---\nkey: value\nlist:\n  - 1\n  - 2\n---'
 var doc = 'Here is a document\nMore of the document\nOther lines\n'
@@ -37,6 +38,15 @@ test('vfile-matter', function (t) {
 
   file = matter(vfile(), {strip: true})
   t.ok(file.contents === undefined, 'should supporting empties')
+
+  file = matter(vfile({contents: '---\ndate: 2021-01-01\n---\n'}), {
+    yaml: {schema: CORE_SCHEMA}
+  })
+  t.deepEqual(
+    file.data,
+    {matter: {date: '2021-01-01'}},
+    'should pass yaml options'
+  )
 
   t.end()
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 // TypeScript Version: 3.7
 
 import {VFile, VFileCompatible} from 'vfile'
+import {LoadOptions} from 'js-yaml'
 
 export = matter
 
@@ -23,5 +24,9 @@ declare namespace matter {
      * Remove the YAML front matter from the file
      */
     strip?: boolean
+    /**
+     * Options for the YAML parser.
+     */
+    yaml?: Omit<LoadOptions, 'filename'>
   }
 }

--- a/types/vfile-matter-tests.ts
+++ b/types/vfile-matter-tests.ts
@@ -1,10 +1,13 @@
 import vfile = require('vfile')
 import matter = require('vfile-matter')
+import {CORE_SCHEMA} from 'js-yaml'
 
 const file = vfile()
 
 matter(file) // $ExpectType VFile
 matter(file, {strip: true}) // $ExpectType VFile
+matter(file, {yaml: {schema: CORE_SCHEMA}}) // $ExpectType VFile
 matter(file, {}) // $ExpectType VFile
 matter(1) // $ExpectError
 matter(file, {strip: 'string'}) // $ExpectError
+matter(file, {yaml: 'string'}) // $ExpectError


### PR DESCRIPTION
This allows passing options to the `js-yaml` parser.

My main motivation is to set the YAML schema to ["Core Schema"](https://yaml.org/spec/1.2/spec.html#id2804923), which is also what [the other javascript yaml parser](https://eemeli.org/yaml/#schema-options) defaults to, and what (i think) the YAML 1.2 spec [recommends](https://yaml.org/spec/1.2/spec.html#id2804923). E.g. one difference to the [`js-yaml` Default Schema](https://github.com/nodeca/js-yaml#user-content-load-string---options-) is that dates are parsed as strings, and not as `Date` objects.