### PR TITLE
Fix regex to not match thematic breaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ export function matter(file, options = {}) {
   var strip = options.strip
   var yamlOptions = options.yaml || {}
   var doc = String(file)
-  var match = /^---(?:\r?\n|\r)(?:([\s\S]*)(?:\r?\n|\r))?---(?:\r?\n|\r|$)/.exec(
+  var match = /^---(?:\r?\n|\r)(?:([\s\S]*?)(?:\r?\n|\r))?---(?:\r?\n|\r|$)/.exec(
     doc
   )
 

--- a/test.js
+++ b/test.js
@@ -34,6 +34,10 @@ test('vfile-matter', function (t) {
   file = matter(vfile({value: Buffer.from(both)}), {strip: true})
   t.ok(buffer(file.value), 'should supporting buffers')
 
+  var extra = 'Here is a thematic break\n---\nEnd'
+  file = matter(vfile({value: both + extra}), {strip: true})
+  t.deepEqual(String(file), doc + extra, 'should handle thematic breaks')
+
   file = matter(vfile(), {strip: true})
   t.ok(file.value === undefined, 'should supporting empties')
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

i ran into an issue when the markdown body contains a thematic break (`---`), which causes a `YAMLException: expected a single document in the stream, but found more`.

this pr makes the regex non-greedy, which should fix it (i hope).

<!--do not edit: pr-->
