### PR TITLE
Refactor to improve type example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ It exports the additional types [`Options`][api-options] and
 To type `file.data.matter`, you can augment `DataMap` from `vfile` as follows:
 
 ```ts
-import { DataMap } from "vfile"
+import {DataMap} from 'vfile'
 
 declare module 'vfile' {
   interface DataMap {

--- a/readme.md
+++ b/readme.md
@@ -169,8 +169,6 @@ It exports the additional types [`Options`][api-options] and
 To type `file.data.matter`, you can augment `DataMap` from `vfile` as follows:
 
 ```ts
-export {}
-
 declare module 'vfile' {
   interface DataMap {
     matter: {
@@ -179,6 +177,8 @@ declare module 'vfile' {
     }
   }
 }
+
+export {} // You may not need this, but it makes sure the file is a module.
 ```
 
 ## Compatibility

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,8 @@ It exports the additional types [`Options`][api-options] and
 To type `file.data.matter`, you can augment `DataMap` from `vfile` as follows:
 
 ```ts
+import { DataMap } from "vfile"
+
 declare module 'vfile' {
   interface DataMap {
     matter: {

--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ It exports the additional types [`Options`][api-options] and
 To type `file.data.matter`, you can augment `DataMap` from `vfile` as follows:
 
 ```ts
-import {DataMap} from 'vfile'
+export {}
 
 declare module 'vfile' {
   interface DataMap {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes
If a d.ts file is created like the example in the readme,  an error is raised when you import `VFile` in another file.
`Module '"vfile"' has no exported member 'VFile'.`

This is fixed by adding an import to the d.ts file to the original `Datamap`.

Fixed example:
```ts
export {}

declare module "vfile" {
  interface DataMap {
    matter: {
      // `file.data.matter.string` is typed as `string | undefined`.
      hex?: string | undefined
    }
  }
}
```
For reference, this seems to be a related comment: https://github.com/Microsoft/TypeScript/issues/9748#issuecomment-232822688



<!--do not edit: pr-->
