### PR TITLE
fix: don't crash on empty frontmatter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ export function matter(file, options) {
   const match = regex.exec(doc)
 
   if (match) {
-    file.data.matter = yaml.parse(match[1] ?? '', yamlOptions)
+    file.data.matter = yaml.parse(match[1] || '', yamlOptions)
 
     if (strip) {
       doc = doc.slice(match[0].length)

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ export function matter(file, options) {
   const match = regex.exec(doc)
 
   if (match) {
-    file.data.matter = yaml.parse(match[1], yamlOptions)
+    file.data.matter = yaml.parse(match[1] ?? '', yamlOptions)
 
     if (strip) {
       doc = doc.slice(match[0].length)

--- a/test.js
+++ b/test.js
@@ -74,11 +74,18 @@ test('matter', async function () {
     {matter: {true: false}},
     'should pass yaml options (2)'
   )
+  file = new VFile('---\n\n---\n')
+  matter(file, {yaml: {version: '1.1'}})
+  assert.deepEqual(
+    file.data,
+    {matter: null},
+    'should not crash on empty frontmatter'
+  )
   file = new VFile('---\n---\n')
   matter(file, {yaml: {version: '1.1'}})
   assert.deepEqual(
     file.data,
-    {matter: {}},
+    {matter: null},
     'should not crash on empty frontmatter'
   )
 })

--- a/test.js
+++ b/test.js
@@ -74,4 +74,11 @@ test('matter', async function () {
     {matter: {true: false}},
     'should pass yaml options (2)'
   )
+  file = new VFile('---\n---\n')
+  matter(file, {yaml: {version: '1.1'}})
+  assert.deepEqual(
+    file.data,
+    {matter: {}},
+    'should not crash on empty frontmatter'
+  )
 })


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Avfile&type=issues and https://github.com/orgs/vfile/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Hey!

Small fix in case someone tries to parse an empty frontmatter:

```md
----
----

I'm a file
```

In this case, match[1] is undefined, so fallback to an empty string

<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->


<!--do not edit: pr-->
